### PR TITLE
Provide lookup tables of callback functions for "special treatment"

### DIFF
--- a/example_setups/example_blue_800x480.toml
+++ b/example_setups/example_blue_800x480.toml
@@ -423,7 +423,9 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #      lfill    Font fill color for label string
 #
 #
-#   Special treatment exists for the 'codec' and 'artist' text fields.
+#   Internal callbacks are used for the 'codec' and 'artist' text
+#   fields.  End-user scripts are free to augment or modify the
+#   callback tables (look for ELEMENT_CB and STRING_CB).
 #
 # --------------------------------------------------------------------
 
@@ -485,7 +487,7 @@ font = "font_tiny"
 fill = "white"
 
 [[A_LAYOUT.A_DEFAULT.fields]]
-name = "codec"   # special treatment in audio_screens()
+name = "codec"   # internal callback
 posx = 580
 posy = 132
 font = "font_tiny"
@@ -529,7 +531,7 @@ trunc = 1
 #
 
 [[A_LAYOUT.A_DEFAULT.fields]]
-name  = "artist"   # special treatment in audio_screens()
+name  = "artist"   # internal callback
 posx  = 420
 posy  = 240
 font  = "font_artist"
@@ -638,7 +640,7 @@ font = "font_tiny"
 fill = "white"
 
 [[A_LAYOUT.A_NOTIME.fields]]
-name = "codec"   # special treatment in audio_screens()
+name = "codec"   # internal callback
 posx = 580
 posy = 62
 font = "font_tiny"
@@ -682,7 +684,7 @@ trunc = 1
 #
 
 [[A_LAYOUT.A_NOTIME.fields]]
-name  = "artist"   # special treatment in audio_screens()
+name  = "artist"   # internal callback
 posx  = 420
 posy  = 240
 font  = "font_artist"
@@ -715,8 +717,6 @@ max_lines = 4
 #
 #   If a completely new InfoLabel is desired, then one must also
 #   augment the VIDEO_LABELS list (see earlier in this file).
-#
-#   Special treatment may exist for text fields within video_screens()
 #
 # --------------------------------------------------------------------
 
@@ -805,7 +805,7 @@ center = 1
 #   that appears following a screen touch when idle.  The screen
 #   gets drawn by status_screen().
 #
-#   Special treatment exists for several field names
+#   Internal callbacks are used for several fields.
 #
 
 [STATUS_LAYOUT.thumb]   # Kodi logo
@@ -814,7 +814,7 @@ posy = 5
 size = 128
 
 [[STATUS_LAYOUT.fields]]
-name = "version"        # special treatment
+name = "version"        # internal callback
 posx = 145
 posy = 8
 font = "font_main"
@@ -822,14 +822,14 @@ fill = "yellow"
 
 
 [[STATUS_LAYOUT.fields]]
-name = "summary"        # special treatment
+name = "summary"    
 posx = 145
 posy = 40
 font = "font_main"
 fill = "white"
 
 [[STATUS_LAYOUT.fields]]
-name = "time_hrmin"     # special treatment
+name = "time_hrmin"     # internal callback
 posx = 145
 posy = 90
 font = "font7S"
@@ -837,7 +837,7 @@ fill = "#00FF78"
 smfont = "font7S_sm"    # used for AM / PM
 
 # The remaining fields all get populated via a special JSON-RPC query
-# to Kodi specifically for the status screen.
+# to Kodi specifically for the status screen.  See STATUS_LABELS above.
 
 [[STATUS_LAYOUT.fields]]
 name = "System.Date"
@@ -863,7 +863,7 @@ font = "font_sm"
 fill = "white"
 
 [[STATUS_LAYOUT.fields]]
-name = "kodi_version"  # special treatment
+name = "kodi_version"  # internal callback
 posx = 5
 posy = 290
 font = "font_sm"

--- a/example_setups/example_blue_800x480.toml
+++ b/example_setups/example_blue_800x480.toml
@@ -23,8 +23,8 @@ BASE_URL = "http://localhost:8080"
 # Specify the size of the display in pixels.  These values get stored
 # into a tuple within kodi_panel and MUST match how the display (or
 # framebuffer) is configured.
-DISPLAY_WIDTH  = 800 
-DISPLAY_HEIGHT = 480 
+DISPLAY_WIDTH  = 800
+DISPLAY_HEIGHT = 480
 
 # GPIO assignment for screen's touch interrupt (T_IRQ), using RPi.GPIO
 # numbering.
@@ -119,7 +119,7 @@ ENABLE_VIDEO_SCREENS = true
 
 # List of additional InfoLabels to retrieve for status screen
 STATUS_LABELS = [
-   "System.OSVersionInfo"   
+   "System.OSVersionInfo"
 ]
 
 # List of additional InfoLabels to retrieve for audio screen(s)
@@ -164,7 +164,7 @@ ALAYOUT_INITIAL = "A_DEFAULT"
 #
 #   If that flag is set to true, then VLAYOUT_NAMES should be
 #   populated with entries that match the heuristic if-then that is
-#   used by video_screens(). 
+#   used by video_screens().
 #
 #   If that variable is to false or left undeclared, then video modes
 #   just form a cycle that gets advanced via the touch interrupt, as
@@ -202,7 +202,7 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #    #00A0E3        blue, close to an LED
 #    #3399ff        skyblue
 #    #38bde8        Kodi logo's blue
-#  
+#
 #   Artist
 #   ------
 #    yellow
@@ -234,7 +234,7 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #
 #
 #  After lots o'indecision, I decided to go with the light amber!
-#  
+#
 #
 [COLORS]
  color_artist = '#ffcc00'    # artist name
@@ -258,7 +258,7 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 [[fonts]]
   name = "font_main"
   path = "fonts/Roboto-Light.ttf"
-  size = 28 
+  size = 28
   encoding = 'unic'
 
 # The "font_bold" below is what the layouts below all use for the
@@ -269,7 +269,7 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 [[fonts]]
   name = "font_bold"
 #  path = "fonts/RobotoCondensed-Light.ttf"
-  path = "fonts/ArchivoNarrow-Medium.ttf"  
+  path = "fonts/ArchivoNarrow-Medium.ttf"
   size = 54
   encoding = 'unic'
 
@@ -283,13 +283,13 @@ VLAYOUT_INITIAL = "V_DEFAULT"
   name = "font_artist"
   path = "fonts/Roboto-Medium.ttf"
   size = 30
-  encoding = 'unic'  
+  encoding = 'unic'
 
 [[fonts]]
   name = "font_tiny"
   path = "fonts/Roboto-Light.ttf"
   size = 22
-  encoding = 'unic'  
+  encoding = 'unic'
 
 # 7-segment font used for elapsed time and track number
 [[fonts]]
@@ -322,15 +322,15 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #     [shared_element.elapsed_time]
 #      name = "MusicPlayer.Time"
 #      posx = 420
-#      posy = 36 
+#      posy = 36
 #      font = "font7S"
 #      fill = "color_7S"
 #      dynamic = 1
-#     
+#
 #     [shared_element.progress_bar]
-#      posx   = 420   
-#      posy   = 8     
-#      height = 12    
+#      posx   = 420
+#      posy   = 8
+#      height = 12
 #      short_len = 196
 #      long_len  = 300
 #      color_fg = "color_7S"
@@ -344,10 +344,10 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #     [A_LAYOUT.A_FULLSCREEN.thumb]
 #     center = 1
 #     size = 480
-#     
+#
 #     [A_LAYOUT.A_FULLSCREEN.prog]
 #      shared_element = "progress_bar"
-#     
+#
 #     [[A_LAYOUT.A_FULLSCREEN.fields]]
 #      shared_element = "elapsed_time"
 #
@@ -439,7 +439,7 @@ posy = 4
 size = 405
 # If artwork is smaller than the above size, should it be centered
 # where the fullsize artwork would have been placed?
-center_sm = 1    
+center_sm = 1
 
 [A_LAYOUT.A_DEFAULT.prog]    # Progress Bar
 posx   = 420     # upper-left corner x position
@@ -453,7 +453,7 @@ color_bg = "color_gray"
 [[A_LAYOUT.A_DEFAULT.fields]]
 name = "MusicPlayer.Time"
 posx = 420
-posy = 36 
+posy = 36
 font = "font7S"
 fill = "color_7S"
 dynamic = 1
@@ -603,7 +603,7 @@ fill = "color_7S"
 posx = 3
 posy = 4
 size = 405
-center_sm = 1    
+center_sm = 1
 
 [A_LAYOUT.A_NOTIME.prog]    # Progress Bar
 posx   = 420     # upper-left corner x position
@@ -744,7 +744,7 @@ color_bg = "color_gray"
 [[V_LAYOUT.V_DEFAULT.fields]]
 name = "VideoPlayer.Time"
 posx = 340
-posy = 31 
+posy = 31
 font = "font7S"
 fill = "color_7S"
 dynamic = 1
@@ -822,7 +822,7 @@ fill = "yellow"
 
 
 [[STATUS_LAYOUT.fields]]
-name = "summary"    
+name = "summary"
 posx = 145
 posy = 40
 font = "font_main"

--- a/example_setups/example_blue_800x480.toml
+++ b/example_setups/example_blue_800x480.toml
@@ -395,6 +395,11 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #                 substitute, enclosed within curly braces.  See the
 #                 status layout screen text fields for examples.
 #
+#                 Terms to be substituted can also make use of any
+#                 entries defined within the string-manipulation
+#                 callback table (see the STRING_CB dictionary in
+#                 kodi_panel_display.py)
+#
 #      trunc    Flag indicating that single line string should
 #               truncated at the right-hand edge of the display
 #

--- a/example_setups/example_setup_320x240.toml
+++ b/example_setups/example_setup_320x240.toml
@@ -166,7 +166,7 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #
 [COLORS]
  color_gray   = '#424242'    # progress bar background (used 'dimgrey' for a while)
- color_7S     = '#00FF78'    # 7-Segment color (used 'SpringGreen' for a while) 
+ color_7S     = '#00FF78'    # 7-Segment color (used 'SpringGreen' for a while)
  color_artist = 'yellow'     # artist name
 
 
@@ -197,13 +197,13 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
   name = "font_sm"
   path = "fonts/FreeSans.ttf"
   size = 18
-  encoding = 'unic'  
+  encoding = 'unic'
 
 [[fonts]]
   name = "font_tiny"
   path = "fonts/FreeSans.ttf"
   size = 11
-  encoding = 'unic'  
+  encoding = 'unic'
 
 # 7-segment font used for elapsed time and track number
 [[fonts]]
@@ -236,15 +236,15 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #     [shared_element.elapsed_time]
 #      name = "MusicPlayer.Time"
 #      posx = 420
-#      posy = 36 
+#      posy = 36
 #      font = "font7S"
 #      fill = "color_7S"
 #      dynamic = 1
-#     
+#
 #     [shared_element.progress_bar]
-#      posx   = 420   
-#      posy   = 8     
-#      height = 12    
+#      posx   = 420
+#      posy   = 8
+#      height = 12
 #      short_len = 196
 #      long_len  = 300
 #      color_fg = "color_7S"
@@ -258,10 +258,10 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #     [A_LAYOUT.A_FULLSCREEN.thumb]
 #     center = 1
 #     size = 480
-#     
+#
 #     [A_LAYOUT.A_FULLSCREEN.prog]
 #      shared_element = "progress_bar"
-#     
+#
 #     [[A_LAYOUT.A_FULLSCREEN.fields]]
 #      shared_element = "elapsed_time"
 #
@@ -353,7 +353,7 @@ posy = 7
 size = 140
 # If artwork is smaller than the above size, should it be centered
 # where the fullsize artwork would have been placed?
-center_sm = 1  
+center_sm = 1
 
 [A_LAYOUT.A_DEFAULT.prog]    # Progress Bar
 posx   = 150     # upper-left corner x position
@@ -571,4 +571,3 @@ posy = 200
 format_str = "CPU: {System.CPUTemperature}, {System.CpuFrequency}"
 font = "font_sm"
 fill = "white"
-

--- a/example_setups/example_setup_320x240.toml
+++ b/example_setups/example_setup_320x240.toml
@@ -337,8 +337,9 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #      lfill    Font fill color for label string
 #
 #
-#
-#   Special treatment exists for the 'codec' and 'artist' text fields.
+#   Internal callbacks are used for the 'codec' and 'artist' text
+#   fields.  End-user scripts are free to augment or modify the
+#   callback tables (look for ELEMENT_CB and STRING_CB).
 #
 # --------------------------------------------------------------------
 
@@ -397,7 +398,7 @@ font = "font_tiny"
 fill = "white"
 
 [[A_LAYOUT.A_DEFAULT.fields]]
-name = "codec"   # special treatment in audio_screens()
+name = "codec"   # internal callback
 posx = 230
 posy = 79
 font = "font_tiny"
@@ -421,7 +422,6 @@ posy = 107
 font = "font_tiny"
 fill = "white"
 
-
 #
 # Finally, the track title, album title, and artist appear below
 # the cover art.
@@ -444,7 +444,7 @@ fill  = "white"
 trunc = 1
 
 [[A_LAYOUT.A_DEFAULT.fields]]
-name  = "artist"   # special treatment in audio_screens()
+name  = "artist"   # internal callback
 posx  = 4
 posy  = 205
 font  = "font_sm"
@@ -495,8 +495,6 @@ color_bg = "color_gray"
 #   If a completely new InfoLabel is desired, then one must also
 #   augment the VIDEO_LABELS list (see earlier in this file).
 #
-#   Special treatment may exist for text fields within video_screens()
-#
 # --------------------------------------------------------------------
 
 #
@@ -516,7 +514,7 @@ center = 1
 #   that appears following a screen touch when idle.  The screen
 #   gets drawn by status_screen().
 #
-#   Special treatment exists for several field names
+#   Internal callbacks are used for some fields
 #
 
 [STATUS_LAYOUT.thumb]   # Kodi logo
@@ -525,7 +523,7 @@ posy = 5
 size = 128
 
 [[STATUS_LAYOUT.fields]]
-name = "version"        # special treatment
+name = "version"        # internal callback
 posx = 145
 posy = 8
 font = "font_main"
@@ -533,14 +531,14 @@ fill = "color_artist"
 
 
 [[STATUS_LAYOUT.fields]]
-name = "summary"        # special treatment
+name = "summary"
 posx = 145
 posy = 35
 font = "font_main"
 fill = "white"
 
 [[STATUS_LAYOUT.fields]]
-name = "time_hrmin"     # special treatment
+name = "time_hrmin"     # internal callback
 posx = 145
 posy = 73
 font = "font7S"
@@ -548,7 +546,8 @@ fill = "color_7S"
 smfont = "font7S_sm"    # used for AM / PM
 
 # The remaining fields all get populated via a special JSON-RPC query
-# to Kodi specifically for the status screen.
+# to Kodi specifically for the status screen.  See STATUS_LABELS
+# above.
 
 [[STATUS_LAYOUT.fields]]
 name = "System.Date"

--- a/example_setups/example_setup_320x240.toml
+++ b/example_setups/example_setup_320x240.toml
@@ -309,6 +309,11 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #                 substitute, enclosed within curly braces.  See the
 #                 status layout screen text fields for examples.
 #
+#                 Terms to be substituted can also make use of any
+#                 entries defined within the string-manipulation
+#                 callback table (see the STRING_CB dictionary in
+#                 kodi_panel_display.py)
+#
 #      trunc    Flag indicating that single line string should
 #               truncated at the right-hand edge of the display
 #

--- a/example_setups/example_setup_480x320.toml
+++ b/example_setups/example_setup_480x320.toml
@@ -338,7 +338,9 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #      lfill    Font fill color for label string
 #
 #
-#   Special treatment exists for the 'codec' and 'artist' text fields.
+#   Internal callbacks are used for the 'codec' and 'artist' text
+#   fields.  End-user scripts are free to augment or modify the
+#   callback tables (look for ELEMENT_CB and STRING_CB).
 #
 # --------------------------------------------------------------------
 
@@ -399,7 +401,7 @@ font = "font_tiny"
 fill = "white"
 
 [[A_LAYOUT.A_DEFAULT.fields]]
-name = "codec"   # special treatment in audio_screens()
+name = "codec"   # internal callback
 posx = 335
 posy = 98
 font = "font_tiny"
@@ -445,7 +447,7 @@ fill  = "white"
 trunc = 1
 
 [[A_LAYOUT.A_DEFAULT.fields]]
-name  = "artist"   # special treatment in audio_screens()
+name  = "artist"   # internal callback
 posx  = 4
 posy  = 295
 font  = "font_sm"
@@ -496,8 +498,6 @@ color_bg = "color_gray"
 #   If a completely new InfoLabel is desired, then one must also
 #   augment the VIDEO_LABELS list (see earlier in this file).
 #
-#   Special treatment may exist for text fields within video_screens()
-#
 # --------------------------------------------------------------------
 
 #
@@ -517,7 +517,7 @@ center = 1
 #   that appears following a screen touch when idle.  The screen
 #   gets drawn by status_screen().
 #
-#   Special treatment exists for several field names
+#   Internal callbacks are used for several field names
 #
 
 [STATUS_LAYOUT.thumb]   # Kodi logo
@@ -526,7 +526,7 @@ posy = 5
 size = 128
 
 [[STATUS_LAYOUT.fields]]
-name = "version"        # special treatment
+name = "version"        # internal callback
 posx = 145
 posy = 8
 font = "font_main"
@@ -534,14 +534,14 @@ fill = "color_artist"
 
 
 [[STATUS_LAYOUT.fields]]
-name = "summary"        # special treatment
+name = "summary"
 posx = 145
 posy = 35
 font = "font_main"
 fill = "white"
 
 [[STATUS_LAYOUT.fields]]
-name = "time_hrmin"     # special treatment
+name = "time_hrmin"     # internal callback
 posx = 145
 posy = 73
 font = "font7S"
@@ -549,7 +549,7 @@ fill = "color_7S"
 smfont = "font7S_sm"    # used for AM / PM
 
 # The remaining fields all get populated via a special JSON-RPC query
-# to Kodi specifically for the status screen.
+# to Kodi specifically for the status screen.  See STATUS_LABELS above.
 
 [[STATUS_LAYOUT.fields]]
 name = "System.Date"
@@ -575,7 +575,7 @@ font = "font_sm"
 fill = "white"
 
 [[STATUS_LAYOUT.fields]]
-name = "kodi_version"  # special treatment
+name = "kodi_version"  # internal callback
 posx = 5
 posy = 225
 font = "font_sm"

--- a/example_setups/example_setup_480x320.toml
+++ b/example_setups/example_setup_480x320.toml
@@ -22,8 +22,8 @@ BASE_URL = "http://localhost:8080"
 # Specify the size of the display in pixels.  These values get stored
 # into a tuple within kodi_panel and MUST match how the display (or
 # framebuffer) is configured.
-DISPLAY_WIDTH  = 480 
-DISPLAY_HEIGHT = 320 
+DISPLAY_WIDTH  = 480
+DISPLAY_HEIGHT = 320
 
 # GPIO assignment for screen's touch interrupt (T_IRQ), using RPi.GPIO
 # numbering.
@@ -141,7 +141,7 @@ ALAYOUT_INITIAL = "A_DEFAULT"
 #
 #   If that flag is set to true, then VLAYOUT_NAMES should be
 #   populated with entries that match the heuristic if-then that is
-#   used by video_screens().  
+#   used by video_screens().
 #
 #   If that variable is to false or left undeclared, then video modes
 #   just form a cycle that gets advanced via the touch interrupt, as
@@ -168,7 +168,7 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #
 [COLORS]
  color_gray   = '#424242'    # progress bar background (used 'dimgrey' for a while)
- color_7S     = '#00FF78'    # 7-Segment color (used 'SpringGreen' for a while) 
+ color_7S     = '#00FF78'    # 7-Segment color (used 'SpringGreen' for a while)
  color_artist = 'yellow'     # artist name
 
 
@@ -199,13 +199,13 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
   name = "font_sm"
   path = "fonts/Roboto-Medium.ttf"
   size = 18
-  encoding = 'unic'  
+  encoding = 'unic'
 
 [[fonts]]
   name = "font_tiny"
   path = "fonts/Roboto-Medium.ttf"
   size = 16
-  encoding = 'unic'  
+  encoding = 'unic'
 
 # 7-segment font used for elapsed time and track number
 [[fonts]]
@@ -238,15 +238,15 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #     [shared_element.elapsed_time]
 #      name = "MusicPlayer.Time"
 #      posx = 420
-#      posy = 36 
+#      posy = 36
 #      font = "font7S"
 #      fill = "color_7S"
 #      dynamic = 1
-#     
+#
 #     [shared_element.progress_bar]
-#      posx   = 420   
-#      posy   = 8     
-#      height = 12    
+#      posx   = 420
+#      posy   = 8
+#      height = 12
 #      short_len = 196
 #      long_len  = 300
 #      color_fg = "color_7S"
@@ -260,10 +260,10 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #     [A_LAYOUT.A_FULLSCREEN.thumb]
 #     center = 1
 #     size = 480
-#     
+#
 #     [A_LAYOUT.A_FULLSCREEN.prog]
 #      shared_element = "progress_bar"
-#     
+#
 #     [[A_LAYOUT.A_FULLSCREEN.fields]]
 #      shared_element = "elapsed_time"
 #
@@ -354,7 +354,7 @@ posy = 4
 size = 228
 # If artwork is smaller than the above size, should it be centered
 # where the fullsize artwork would have been placed?
-center_sm = 1    
+center_sm = 1
 
 [A_LAYOUT.A_DEFAULT.prog]    # Progress Bar
 posx   = 245     # upper-left corner x position

--- a/example_setups/example_setup_480x320.toml
+++ b/example_setups/example_setup_480x320.toml
@@ -310,6 +310,11 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #                 substitute, enclosed within curly braces.  See the
 #                 status layout screen text fields for examples.
 #
+#                 Terms to be substituted can also make use of any
+#                 entries defined within the string-manipulation
+#                 callback table (see the STRING_CB dictionary in
+#                 kodi_panel_display.py)
+#
 #      trunc    Flag indicating that single line string should
 #               truncated at the right-hand edge of the display
 #

--- a/example_setups/example_setup_800x480.toml
+++ b/example_setups/example_setup_800x480.toml
@@ -336,6 +336,11 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #                 substitute, enclosed within curly braces.  See the
 #                 status layout screen text fields for examples.
 #
+#                 Terms to be substituted can also make use of any
+#                 entries defined within the string-manipulation
+#                 callback table (see the STRING_CB dictionary in
+#                 kodi_panel_display.py)
+#
 #      trunc    Flag indicating that single line string should
 #               truncated at the right-hand edge of the display
 #

--- a/example_setups/example_setup_800x480.toml
+++ b/example_setups/example_setup_800x480.toml
@@ -263,15 +263,15 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #     [shared_element.elapsed_time]
 #      name = "MusicPlayer.Time"
 #      posx = 420
-#      posy = 36 
+#      posy = 36
 #      font = "font7S"
 #      fill = "color_7S"
 #      dynamic = 1
-#     
+#
 #     [shared_element.progress_bar]
-#      posx   = 420   
-#      posy   = 8     
-#      height = 12    
+#      posx   = 420
+#      posy   = 8
+#      height = 12
 #      short_len = 196
 #      long_len  = 300
 #      color_fg = "color_7S"
@@ -285,10 +285,10 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #     [A_LAYOUT.A_FULLSCREEN.thumb]
 #     center = 1
 #     size = 480
-#     
+#
 #     [A_LAYOUT.A_FULLSCREEN.prog]
 #      shared_element = "progress_bar"
-#     
+#
 #     [[A_LAYOUT.A_FULLSCREEN.fields]]
 #      shared_element = "elapsed_time"
 #

--- a/example_setups/example_setup_800x480.toml
+++ b/example_setups/example_setup_800x480.toml
@@ -364,7 +364,9 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #      lfill    Font fill color for label string
 #
 #
-#   Special treatment exists for the 'codec' and 'artist' text fields.
+#   Internal callbacks are used for the 'codec' and 'artist' text
+#   fields.  End-user scripts are free to augment or modify the
+#   callback tables (look for ELEMENT_CB and STRING_CB).
 #
 # --------------------------------------------------------------------
 
@@ -425,7 +427,7 @@ font = "font_tiny"
 fill = "white"
 
 [[A_LAYOUT.A_DEFAULT.fields]]
-name = "codec"   # special treatment in audio_screens()
+name = "codec"   # internal callback
 posx = 580
 posy = 132
 font = "font_tiny"
@@ -467,7 +469,7 @@ trunc = 1
 #
 
 [[A_LAYOUT.A_DEFAULT.fields]]
-name  = "artist"   # special treatment in audio_screens()
+name  = "artist"   # internal callback
 posx  = 420
 posy  = 240
 font  = "font_sm"
@@ -562,7 +564,7 @@ font = "font_tiny"
 fill = "white"
 
 [[A_LAYOUT.A_NOTIME.fields]]
-name = "codec"   # special treatment in audio_screens()
+name = "codec"   # internal callback
 posx = 580
 posy = 58
 font = "font_tiny"
@@ -606,7 +608,7 @@ trunc = 1
 #
 
 [[A_LAYOUT.A_NOTIME.fields]]
-name  = "artist"   # special treatment in audio_screens()
+name  = "artist"   # internal callback
 posx  = 420
 posy  = 240
 font  = "font_sm"
@@ -639,8 +641,6 @@ max_lines = 4
 #
 #   If a completely new InfoLabel is desired, then one must also
 #   augment the VIDEO_LABELS list (see earlier in this file).
-#
-#   Special treatment may exist for text fields within video_screens()
 #
 # --------------------------------------------------------------------
 
@@ -727,7 +727,7 @@ center = 1
 #   that appears following a screen touch when idle.  The screen
 #   gets drawn by status_screen().
 #
-#   Special treatment exists for several field names
+#   Internal callbacks are used for several fields.
 #
 
 [STATUS_LAYOUT.thumb]   # Kodi logo
@@ -736,7 +736,7 @@ posy = 5
 size = 128
 
 [[STATUS_LAYOUT.fields]]
-name = "version"        # special treatment
+name = "version"        # internal callback
 posx = 145
 posy = 8
 font = "font_main"
@@ -744,14 +744,14 @@ fill = "color_artist"
 
 
 [[STATUS_LAYOUT.fields]]
-name = "summary"        # special treatment
+name = "summary"
 posx = 145
 posy = 40
 font = "font_main"
 fill = "white"
 
 [[STATUS_LAYOUT.fields]]
-name = "time_hrmin"     # special treatment
+name = "time_hrmin"     # internal callback
 posx = 145
 posy = 90
 font = "font7S"
@@ -759,7 +759,7 @@ fill = "color_7S"
 smfont = "font7S_sm"    # used for AM / PM
 
 # The remaining fields all get populated via a special JSON-RPC query
-# to Kodi specifically for the status screen.
+# to Kodi specifically for the status screen.  See STATUS_LABELS above.
 
 [[STATUS_LAYOUT.fields]]
 name = "System.Date"
@@ -785,7 +785,7 @@ font = "font_sm"
 fill = "white"
 
 [[STATUS_LAYOUT.fields]]
-name = "kodi_version"  # special treatment
+name = "kodi_version"  # internal callback
 posx = 5
 posy = 290
 font = "font_sm"

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -578,8 +578,7 @@ def element_codec(image, draw, info, field, screen_mode, layout_name):
             return codec_name[info['MusicPlayer.Codec']]
         else:
             return info['MusicPlayer.Codec']
-    else:
-        return ""
+    return ""
 
 
 # Similar function for AudioCodec lookup when playing video
@@ -590,8 +589,7 @@ def element_acodec(image, draw, info, field, screen_mode, layout_name):
             return codec_name[info['VideoPlayer.AudioCodec']]
         else:
             return info['VideoPlayer.AudioCodec']        
-    else:
-        return ""
+    return ""
     
 
 # Construct a string containing both the friendly codec name and, in
@@ -616,7 +614,8 @@ def element_full_codec(image, draw, info, field, screen_mode, layout_name):
         # augment with (bit/sample) information
         display_text += " (" + info['MusicPlayer.BitsPerSample'] + "/" + \
             info['MusicPlayer.SampleRate'] + ")"
-            
+
+        return display_text
     else:
         return ""
 
@@ -650,9 +649,8 @@ def element_audio_artist(image, draw, info, field, screen_mode, layout_name):
             if (display_string == "Unknown" and field.get("drop_unknown", 0)):
                 display_string = ""
 
-            return display_string
-    else:
-        return ""
+        return display_string
+    return ""
 
 
 
@@ -668,8 +666,7 @@ def element_kodi_version(image, draw, info, field, screen_mode, layout_name):
         kodi_version = info["System.BuildVersion"].split()[0]
         build_date   = info["System.BuildDate"]
         return "Kodi version: " + kodi_version + " (" + build_date + ")"
-    else:
-        return ""
+    return ""
 
 
 # Render current time and, in what should be a smaller font, AM/PM.

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -618,7 +618,6 @@ def element_full_codec(image, draw, info, field, screen_mode, layout_name):
         return ""
 
 
-
 # Process an audio file's listed Artist, instead displaying the
 # Composer parenthetically if the artist field is empty.
 #
@@ -654,7 +653,38 @@ def element_audio_artist(image, draw, info, field, screen_mode, layout_name):
 
 
 
-    
+# Return string with current kodi_panel version    
+def element_version(image, draw, info, field, screen_mode, layout_name):
+    return "kodi_panel " + PANEL_VER
+
+
+# Return a friendlier version of Kodi build information
+def element_kodi_version(image, draw, info, field, screen_mode, layout_name):
+    if ("System.BuildVersion" in info and
+        "System.BuildDate" in info):
+        kodi_version = info["System.BuildVersion"].split()[0]
+        build_date   = info["System.BuildDate"]
+        return "Kodi version: " + kodi_version + " (" + build_date + ")"
+    else:
+        return ""
+
+
+# Render current time and, in what should be a smaller font, AM/PM.
+# Return an empty string so as not to confuse the caller.
+def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
+    if "System.Time" in info:
+        time_parts = info['System.Time'].split(" ")
+        time_width, time_height = draw.textsize(time_parts[0], field["font"])
+        draw.text((field_info["posx"], field["posy"]),
+                  time_parts[0],
+                  field["fill"], field["font"])
+        draw.text((field["posx"] + time_width + 5, field["posy"]),
+                  time_parts[1],
+                  field["fill"], field["smfont"])
+
+    return ""
+        
+
 # Dictionary of element callback functions, with each key
 # corresponding to either the "name" specified for a textfield (within
 # a layout's array of such textfields).
@@ -670,10 +700,15 @@ ELEMENT_CB = {
     'acodec'     : element_codec,
     'full_codec' : element_full_codec,
     'artist'     : element_audio_artist,
+
+    # Status screen fields
+    'version'      : element_version,
+    'kodi_version' : element_kodi_version,
+    'time_hrmin'   : element_time_hrmin,
     }
     
 
-
+# ----------------------------------------------------------------------------
 
 # Text wrapping from public blog post
 #

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -675,7 +675,7 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
     if "System.Time" in info:
         time_parts = info['System.Time'].split(" ")
         time_width, time_height = draw.textsize(time_parts[0], field["font"])
-        draw.text((field_info["posx"], field["posy"]),
+        draw.text((field["posx"], field["posy"]),
                   time_parts[0],
                   field["fill"], field["font"])
         draw.text((field["posx"] + time_width + 5, field["posy"]),
@@ -1130,7 +1130,7 @@ def text_fields(image, draw, layout, info, layout_name, screen_mode, dynamic=Fal
 # Second argument is a dictionary loaded from Kodi system status fields.
 # This argument is the string to use for current state of the system
 #
-def status_screen(draw, kodi_status, summary_string):
+def status_screen(image, draw, kodi_status, summary_string):
     layout = STATUS_LAYOUT
 
     # Kodi logo, if desired
@@ -1146,51 +1146,9 @@ def status_screen(draw, kodi_status, summary_string):
     if "fields" not in layout.keys():
         return
 
-    txt_fields = layout.get("fields", [])
-    for field_info in txt_fields:
-        if field_info["name"] == "version":
-            draw.text((field_info["posx"], field_info["posy"]),
-                      "kodi_panel " + PANEL_VER,
-                      field_info["fill"], field_info["font"])
-
-        elif field_info["name"] == "summary":
-            draw.text((field_info["posx"], field_info["posy"]),
-                      summary_string,
-                      field_info["fill"], field_info["font"])
-
-        elif field_info["name"] == "kodi_version":
-            kodi_version = kodi_status["System.BuildVersion"].split()[0]
-            build_date = kodi_status["System.BuildDate"]
-            draw.text((field_info["posx"], field_info["posy"]),
-                      "Kodi version: " + kodi_version +
-                      " (" + build_date + ")",
-                      field_info["fill"], field_info["font"])
-
-        elif field_info["name"] == "time_hrmin":
-            # current time (in 7-segment LED font by default)
-            time_parts = kodi_status['System.Time'].split(" ")
-            time_width, time_height = draw.textsize(
-                time_parts[0], field_info["font"])
-            draw.text((field_info["posx"], field_info["posy"]),
-                      time_parts[0],
-                      field_info["fill"], field_info["font"])
-            draw.text((field_info["posx"] + time_width + 5, field_info["posy"]),
-                      time_parts[1],
-                      field_info["fill"], field_info["smfont"])
-
-        else:
-            # Use format_str or prefix/suffic approach, in that order
-            if field_info.get("format_str", ""):
-                display_string = format_InfoLabels(
-                    field_info["format_str"], kodi_status)
-            else:
-                display_string = (field_info.get("prefix", "") + kodi_status[field_info["name"]] +
-                                  field_info.get("suffix", ""))
-
-            draw.text((field_info["posx"], field_info["posy"]),
-                      display_string,
-                      field_info["fill"], field_info["font"])
-
+    text_fields(image, draw,
+                layout, kodi_status,
+                "STATUS_LAYOUT", ScreenMode.STATUS)
 
 
             
@@ -1622,7 +1580,11 @@ def update_display(touched=False):
                 rpc_url,
                 data=json.dumps(payload),
                 headers=headers).json()
-            status_screen(draw, status_resp['result'], summary)
+
+            # add the summary string above to the response dictionary
+            status_resp['result']['summary'] = summary
+            
+            status_screen(image, draw, status_resp['result'], summary)
             screen_on()
         else:
             screen_off()

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -1226,9 +1226,9 @@ def text_fields(image, draw, layout, info, screen_mode=None, layout_name="", dyn
 #
 # First argument is a Pillow ImageDraw object.
 # Second argument is a dictionary loaded from Kodi system status fields.
-# This argument is the string to use for current state of the system
+# Third argument is dictionary holding JSON-RPC response from Kodi.
 #
-def status_screen(image, draw, kodi_status, summary_string):
+def status_screen(image, draw, kodi_status):
     layout = STATUS_LAYOUT
 
     # Kodi logo, if desired
@@ -1682,7 +1682,7 @@ def update_display(touched=False):
             # add the summary string above to the response dictionary
             status_resp['result']['summary'] = summary
 
-            status_screen(image, draw, status_resp['result'], summary)
+            status_screen(image, draw, status_resp['result'])
             screen_on()
         else:
             screen_off()

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -573,23 +573,26 @@ def element_empty(image, draw, info, field, screen_mode, layout_name):
 # common names.
 
 def element_codec(image, draw, info, field, screen_mode, layout_name):
-    if (screen_mode == ScreenMode.AUDIO and
-        'MusicPlayer.Codec' in info):
+    if 'MusicPlayer.Codec' in info:
         if info['MusicPlayer.Codec'] in codec_name:
             return codec_name[info['MusicPlayer.Codec']]
         else:
             return info['MusicPlayer.Codec']
-
-    elif (screen_mode == ScreenMode.VIDEO and
-          'VideoPlayer.AudioCodec' in info):
-        if info['VideoPlayer.AudioCodec'] in codec_name.keys():
-            return codec_name[info['VideoPlayer.AudioCodec']]
-        else:
-            return info['VideoPlayer.AudioCodec']
-        
     else:
         return ""
 
+
+# Similar function for AudioCodec lookup when playing video
+
+def element_acodec(image, draw, info, field, screen_mode, layout_name):
+    if 'VideoPlayer.AudioCodec' in info:
+        if info['VideoPlayer.AudioCodec'] in codec_name.keys():
+            return codec_name[info['VideoPlayer.AudioCodec']]
+        else:
+            return info['VideoPlayer.AudioCodec']        
+    else:
+        return ""
+    
 
 # Construct a string containing both the friendly codec name and, in
 # parenthesis, the bit depth and sample rate for the codec.
@@ -697,7 +700,7 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
     
 ELEMENT_CB = {
     'codec'      : element_codec,
-    'acodec'     : element_codec,
+    'acodec'     : element_acodec,
     'full_codec' : element_full_codec,
     'artist'     : element_audio_artist,
 

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -529,8 +529,9 @@ draw = ImageDraw.Draw(image)
 # Element callback functions
 # --------------------------
 #
-# These callbacks take the place of the earlier "special treatment" of
-# textfields.
+# These callbacks provide the "special treatment" of textfields that
+# was previously provided via if-elif trees within audio- and
+# video-specific functions.
 #
 # Each function listed in the ELEMENT_CB dictionary must accept the
 # following 6 arguments:
@@ -687,20 +688,36 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
 
 # Dictionary of element callback functions, with each key
 # corresponding to either the "name" specified for a textfield (within
-# a layout's array of such textfields).
-#
-# FIXME: Extend to top-level elements (thumb, prog) within a layout??
+# a layout's array of such textfields).  
 #
 # Scripts that are making use of kodi_panel_display can change the
 # function assigned to the entries below and add entirely new
-# key/value pairs.
-    
+# key/value pairs.  Prior to invoking
+#
+#   kodi_panel_display.main(device)
+#
+# scripts that wish to install their own callback functions can
+# directly manipulate kodi_panel_display.ELEMENT_CB.  For instance, if
+# a script has a customized codec lookup function, it can make the
+# assignment
+#
+#   kodi_panel_display.ELEMENT_CB["codec"] = my_element_codec
+#
+# provided the my_element_codec() definition has been provided first.
+#
+
+# FIXME: MBL, 19 Jan 21 -- Extend to top-level elements (thumb, prog)
+#        within a layout??
+
 ELEMENT_CB = {
+    # Audio screen fields
     'codec'      : element_codec,
-    'acodec'     : element_acodec,
     'full_codec' : element_full_codec,
     'artist'     : element_audio_artist,
 
+    # Video screen fields
+    'acodec'     : element_acodec,
+    
     # Status screen fields
     'version'      : element_version,
     'kodi_version' : element_kodi_version,

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -652,8 +652,14 @@ def strcb_full_codec(info, screen_mode, layout_name):
 # combination of JRiver Media Center providing DLNA/UPnp playback to
 # Kodi doesn't successfully yield any composer info.  I believe that
 # Kodi's UPnP field parsing is incomplete.
+#
+# This function is an element callback simply to provide access to the
+# possibly-defined "drop_unknown" flag from TOML configuration.  It is
+# possible that functionality (not displaying a field based upon
+# display_string) will be replaced by something more general.
+#
 
-def strcb_audio_artist(info, screen_mode, layout_name):
+def element_audio_artist(image, draw, info, field, screen_mode, layout_name):
     if screen_mode == ScreenMode.AUDIO:
         # The following was an attempt to display Composer if
         # Artist is blank.  The combination of JRiver Media Center
@@ -705,9 +711,9 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
     return ""
 
 
-# Dictionary of element callback functions, with each key
-# corresponding to either the "name" specified for a textfield (within
-# a layout's array of such textfields).
+# Dictionaries of element and string callback functions, with each key
+# corresponding to the "name" specified for a textfield (within a
+# layout's array of such textfields).
 #
 # Scripts that are making use of kodi_panel_display can change the
 # function assigned to the entries below and add entirely new
@@ -716,19 +722,33 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
 #   kodi_panel_display.main(device)
 #
 # scripts that wish to install their own callback functions can
-# directly manipulate kodi_panel_display.ELEMENT_CB.  For instance, if
-# a script has a customized codec lookup function, it can make the
-# assignment
+# directly manipulate
+#
+#    kodi_panel_display.ELEMENT_CB   or
+#    kodi_panel_display.STRING_CB
+#
+# For instance, if a script has a customized codec lookup function, it
+# can make the assignment
 #
 #   kodi_panel_display.ELEMENT_CB["codec"] = my_element_codec
 #
 # provided the my_element_codec() definition has been provided first.
+# Note that existing keys can be removed from either dictionary using
+# a del statement:
 #
+#   del kodi_panel_display.STRING_CB["codec"]
+#
+# Deleting an entry is necessary if one wants to switch an existing
+# key name to reside in the other lookup table.
+# 
 
 # FIXME: MBL, 19 Jan 21 -- Extend to top-level elements (thumb, prog)
 #        within a layout??
 
 ELEMENT_CB = {
+    # Audio screen fields
+    'artist'     : element_audio_artist,
+    
     # Status screen fields
     'time_hrmin' : element_time_hrmin,
     }
@@ -738,7 +758,6 @@ STRING_CB = {
     # Audio screen fields
     'codec'      : strcb_codec,
     'full_codec' : strcb_full_codec,
-    'artist'     : strcb_audio_artist,
 
     # Video screen fields
     'acodec'     : strcb_acodec,

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -741,9 +741,28 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
 # Deleting an entry is necessary if one wants to switch an existing
 # key name to reside in the other lookup table.
 #
+# -------------------
+#
+# NOTE:
+#
+#   It would also be possible to extend this approach to apply to
+#   top-level elements within a layout such as "thumb" and "prog".
+#   However, the end user can *already* override that functionality by
+#
+#    1. Not making use of "thumb" or "prog" in their layouts.
+#
+#    2. Providing equivalent, customized functionality via their
+#       own element callback functions, adding to ELEMENT_CB.
+#
+#    3. Invoking those callbacks by name within the fields
+#       array of their layouts.
+#
+#   So, I believe all of the top-level functionality can be overridden
+#   externally, without needing anything else.
+#       
 
-# FIXME: MBL, 19 Jan 21 -- Extend to top-level elements (thumb, prog)
-#        within a layout??
+
+# Drawing-capable element callback functions
 
 ELEMENT_CB = {
     # Audio screen fields
@@ -753,6 +772,8 @@ ELEMENT_CB = {
     'time_hrmin' : element_time_hrmin,
     }
 
+
+# String-manipulation callback functions
 
 STRING_CB = {
     # Audio screen fields
@@ -1140,7 +1161,7 @@ def text_fields(image, draw, layout, info, screen_mode=None, layout_name="", dyn
                 screen_mode,       # screen mode, as enum
                 layout_name        # layout name, as string
             )
-            # print("Invoked CB for ", field_info["name"],"; received back '", display_string, "'")
+            # print("Invoked element CB for", field_info["name"],"; received back '", display_string, "'")
 
         elif field_info["name"] in STRING_CB:
             display_string = STRING_CB[field_info["name"]](
@@ -1148,6 +1169,7 @@ def text_fields(image, draw, layout, info, screen_mode=None, layout_name="", dyn
                 screen_mode,       # screen mode, as enum
                 layout_name        # layout name, as string
             )
+            # print("Invoked string CB for", field_info["name"],"; received back '", display_string, "'")
 
         else:
             if (field_info["name"] in info.keys() and

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -349,7 +349,7 @@ if VIDEO_ENABLED:
 
 # Screen Mode
 # -----------
-#        
+#
 # Define an enumerated type (well, it's still Python, so a class)
 # representing whether the screen being drawn is for audio playback,
 # video playback, or is just a status screen.
@@ -358,7 +358,7 @@ class ScreenMode(Enum):
     STATUS = 0   # kodi_panel status screen
     AUDIO  = 1   # audio playback is active
     VIDEO  = 2   # video playback is active
-        
+
 
 # Shared Elements
 # ---------------
@@ -585,11 +585,11 @@ draw = ImageDraw.Draw(image)
 # directly make use of format_InfoLabels() themselves.
 
 
-# Empty callback function, largely for testing    
+# Empty callback function, largely for testing
 def element_empty(image, draw, info, field, screen_mode, layout_name):
     return ""
 
-# Empty callback function, largely for testing    
+# Empty callback function, largely for testing
 def strcb_empty(info, screen_mode, layout_name):
     return ""
 
@@ -613,9 +613,9 @@ def strcb_acodec(info, screen_mode, layout_name):
         if info['VideoPlayer.AudioCodec'] in codec_name.keys():
             return codec_name[info['VideoPlayer.AudioCodec']]
         else:
-            return info['VideoPlayer.AudioCodec']        
+            return info['VideoPlayer.AudioCodec']
     return ""
-    
+
 
 # Construct a string containing both the friendly codec name and, in
 # parenthesis, the bit depth and sample rate for the codec.
@@ -653,19 +653,19 @@ def strcb_full_codec(info, screen_mode, layout_name):
 # Kodi doesn't successfully yield any composer info.  I believe that
 # Kodi's UPnP field parsing is incomplete.
 
-def strcb_audio_artist(info, screen_mode, layout_name):    
+def strcb_audio_artist(info, screen_mode, layout_name):
     if screen_mode == ScreenMode.AUDIO:
         # The following was an attempt to display Composer if
         # Artist is blank.  The combination of JRiver Media Center
         # and UPnP/DLNA playback via Kodi didn't quite permit this
         # to work, unfortunately.
-        
+
         if info['MusicPlayer.Artist'] != "":
             display_string = info['MusicPlayer.Artist']
 
         elif info['MusicPlayer.Property(Role.Composer)'] != "":
             display_string = "(" + info['MusicPlayer.Property(Role.Composer)'] + ")"
-            
+
         if (display_string == "Unknown" and field.get("drop_unknown", 0)):
             display_string = ""
 
@@ -674,7 +674,7 @@ def strcb_audio_artist(info, screen_mode, layout_name):
 
 
 
-# Return string with current kodi_panel version    
+# Return string with current kodi_panel version
 def strcb_version(info, screen_mode, layout_name):
     return "kodi_panel " + PANEL_VER
 
@@ -703,11 +703,11 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
                   field["fill"], field["smfont"])
 
     return ""
-        
+
 
 # Dictionary of element callback functions, with each key
 # corresponding to either the "name" specified for a textfield (within
-# a layout's array of such textfields).  
+# a layout's array of such textfields).
 #
 # Scripts that are making use of kodi_panel_display can change the
 # function assigned to the entries below and add entirely new
@@ -732,7 +732,7 @@ ELEMENT_CB = {
     # Status screen fields
     'time_hrmin' : element_time_hrmin,
     }
-    
+
 
 STRING_CB = {
     # Audio screen fields
@@ -742,7 +742,7 @@ STRING_CB = {
 
     # Video screen fields
     'acodec'     : strcb_acodec,
-    
+
     # Status screen fields
     'version'      : strcb_version,
     'kodi_version' : strcb_kodi_version,
@@ -1064,7 +1064,7 @@ def format_InfoLabels(orig_str, kodi_info, screen_mode=None, layout_name=""):
                                           kodi_info,
                                           screen_mode,
                                           layout_name
-                                      ))            
+                                      ))
         else:
             new_str = new_str.replace('{' + field + '}', '')
     return new_str
@@ -1090,7 +1090,7 @@ def format_InfoLabels(orig_str, kodi_info, screen_mode=None, layout_name=""):
 #  screen_mode  Enumerated type indicating AUDIO, VIDEO, or STATUS
 #  layout_name  Name, as a string, for the in-use layout
 #  dynamic      Boolean flag, set for dynamic screen updates
-#  
+#
 #
 def text_fields(image, draw, layout, info, screen_mode=None, layout_name="", dynamic=False):
 
@@ -1098,7 +1098,7 @@ def text_fields(image, draw, layout, info, screen_mode=None, layout_name="", dyn
     txt_fields = layout.get("fields", [])
     for field_info in txt_fields:
         display_string = None
-        
+
         # Skip over the fields that aren't desired for this
         # invocation, based on static vs dynamic
         if dynamic:
@@ -1129,7 +1129,7 @@ def text_fields(image, draw, layout, info, screen_mode=None, layout_name="", dyn
                 screen_mode,       # screen mode, as enum
                 layout_name        # layout name, as string
             )
-            
+
         else:
             if (field_info["name"] in info.keys() and
                 info[field_info["name"]] != ""):
@@ -1142,7 +1142,7 @@ def text_fields(image, draw, layout, info, screen_mode=None, layout_name="", dyn
                     display_string = (field_info.get("prefix", "") +
                                       info[field_info["name"]] +
                                       field_info.get("suffix", ""))
-                
+
 
         # if the string to display is empty, move on to the next field,
         # otherwise render it.
@@ -1208,7 +1208,7 @@ def status_screen(image, draw, kodi_status, summary_string):
                 ScreenMode.STATUS, "STATUS_LAYOUT")
 
 
-            
+
 # Render the static portion of audio screens
 #
 #  First argument is the layout dictionary to use
@@ -1273,7 +1273,7 @@ def audio_screen_dynamic(image, draw, layout, info, prog):
     text_fields(image, draw,
                 layout, info,
                 ScreenMode.AUDIO, audio_dmode.name,
-                dynamic=1)    
+                dynamic=1)
 
     # Progress bar, if present
     if (prog != -1 and "prog" in layout.keys()):
@@ -1381,7 +1381,7 @@ def video_screen_static(layout, info):
     text_fields(image, draw,
                 layout, info,
                 ScreenMode.VIDEO, video_dmode.name,
-                dynamic=0)    
+                dynamic=0)
 
     # Return new image
     return image
@@ -1472,7 +1472,7 @@ def video_screens(image, draw, info, prog):
 
     # Look up video layout details
     layout = VIDEO_LAYOUT[video_dmode.name]
-        
+
     if (_static_image and _static_video and
         info["VideoPlayer.Title"] == _last_video_title and
         info["VideoPlayer.Episode"] == _last_video_episode and
@@ -1640,7 +1640,7 @@ def update_display(touched=False):
 
             # add the summary string above to the response dictionary
             status_resp['result']['summary'] = summary
-            
+
             status_screen(image, draw, status_resp['result'], summary)
             screen_on()
         else:

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -762,7 +762,7 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
 #
 #   So, I believe all of the top-level functionality can be overridden
 #   externally, without needing anything else.
-#       
+#
 
 
 # Drawing-capable element callback functions

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -712,12 +712,12 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
 
 
 # Dictionaries of element and string callback functions, with each key
-# corresponding to the "name" specified for a textfield (within a
-# layout's array of such textfields).
+# corresponding to the "name" specified for a field (within a layout's
+# array named "fields").
 #
 # Scripts that are making use of kodi_panel_display can change the
-# function assigned to the entries below and add entirely new
-# key/value pairs.  Prior to invoking
+# function assigned to the entries below or add entirely new key/value
+# pairs.  Prior to invoking
 #
 #   kodi_panel_display.main(device)
 #
@@ -751,8 +751,11 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
 #
 #    1. Not making use of "thumb" or "prog" in their layouts.
 #
-#    2. Providing equivalent, customized functionality via their
-#       own element callback functions, adding to ELEMENT_CB.
+#    2. Providing equivalent, customized functionality via their own
+#       element callback functions, adding to ELEMENT_CB.  (The new
+#       functions must take some care if referencing any variables
+#       declared in this module's namespace, but such uses are
+#       certainly possible.)
 #
 #    3. Invoking those callbacks by name within the fields
 #       array of their layouts.

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -740,7 +740,7 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
 #
 # Deleting an entry is necessary if one wants to switch an existing
 # key name to reside in the other lookup table.
-# 
+#
 
 # FIXME: MBL, 19 Jan 21 -- Extend to top-level elements (thumb, prog)
 #        within a layout??
@@ -748,7 +748,7 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
 ELEMENT_CB = {
     # Audio screen fields
     'artist'     : element_audio_artist,
-    
+
     # Status screen fields
     'time_hrmin' : element_time_hrmin,
     }

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -727,8 +727,8 @@ def element_time_hrmin(image, draw, info, field, screen_mode, layout_name):
 #    kodi_panel_display.ELEMENT_CB   or
 #    kodi_panel_display.STRING_CB
 #
-# For instance, if a script has a customized codec lookup function, it
-# can make the assignment
+# as part of their startup.  For instance, if a script has a
+# customized codec lookup function, it can make the assignment
 #
 #   kodi_panel_display.ELEMENT_CB["codec"] = my_element_codec
 #


### PR DESCRIPTION
See the `ELEMENT_CB` and `STRING_CB` dictionaries.

Audio, video, and status screen functions can now all make use of a single, centralized `text_fields()` function.
