### PR TITLE
Dev/custom background

### DIFF
--- a/example_setups/example_blue_800x480.toml
+++ b/example_setups/example_blue_800x480.toml
@@ -432,6 +432,33 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #   callback tables (look for ELEMENT_CB and STRING_CB).
 #
 # --------------------------------------------------------------------
+#
+# Background
+#
+#   Every layout, including the status screens, can optional specify a
+#   background entry at the top-level.  A few examples are as follows:
+#
+#     [A_LAYOUT.A_FULLSCREEN.background]
+#      fill = "navy"        # uniform fill color
+#
+#   or
+#
+#     [A_LAYOUT.A_FULLSCREEN.background]
+#      rectangle = 1        # rectangle with frame/border
+#      fill = "navy"
+#      outline = "yellow"
+#      width = 3
+#
+#   or
+#
+#     [STATUS_LAYOUT.background]
+#      image = "images/mickey-sprite.png"   # assumed sized correctly
+#
+#
+#   As shown, the entry must be named "background".
+#
+# --------------------------------------------------------------------
+
 
 #
 # Default audio info screen

--- a/example_setups/example_setup_320x240.toml
+++ b/example_setups/example_setup_320x240.toml
@@ -346,6 +346,33 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #   callback tables (look for ELEMENT_CB and STRING_CB).
 #
 # --------------------------------------------------------------------
+#
+# Background
+#
+#   Every layout, including the status screens, can optional specify a
+#   background entry at the top-level.  A few examples are as follows:
+#
+#     [A_LAYOUT.A_FULLSCREEN.background]
+#      fill = "navy"        # uniform fill color
+#
+#   or
+#
+#     [A_LAYOUT.A_FULLSCREEN.background]
+#      rectangle = 1        # rectangle with frame/border
+#      fill = "navy"
+#      outline = "yellow"
+#      width = 3
+#
+#   or
+#
+#     [STATUS_LAYOUT.background]
+#      image = "images/mickey-sprite.png"   # assumed sized correctly
+#
+#
+#   As shown, the entry must be named "background".
+#
+# --------------------------------------------------------------------
+
 
 #
 # Default audio info screen

--- a/example_setups/example_setup_480x320.toml
+++ b/example_setups/example_setup_480x320.toml
@@ -347,6 +347,32 @@ VLAYOUT_INITIAL = "V_FULLSCREEN"
 #   callback tables (look for ELEMENT_CB and STRING_CB).
 #
 # --------------------------------------------------------------------
+#
+# Background
+#
+#   Every layout, including the status screens, can optional specify a
+#   background entry at the top-level.  A few examples are as follows:
+#
+#     [A_LAYOUT.A_FULLSCREEN.background]
+#      fill = "navy"        # uniform fill color
+#
+#   or
+#
+#     [A_LAYOUT.A_FULLSCREEN.background]
+#      rectangle = 1        # rectangle with frame/border
+#      fill = "navy"
+#      outline = "yellow"
+#      width = 3
+#
+#   or
+#
+#     [STATUS_LAYOUT.background]
+#      image = "images/mickey-sprite.png"   # assumed sized correctly
+#
+#
+#   As shown, the entry must be named "background".
+#
+# --------------------------------------------------------------------
 
 #
 # Default audio info screen

--- a/example_setups/example_setup_800x480.toml
+++ b/example_setups/example_setup_800x480.toml
@@ -373,6 +373,33 @@ VLAYOUT_INITIAL = "V_DEFAULT"
 #   callback tables (look for ELEMENT_CB and STRING_CB).
 #
 # --------------------------------------------------------------------
+#
+# Background
+#
+#   Every layout, including the status screens, can optional specify a
+#   background entry at the top-level.  A few examples are as follows:
+#
+#     [A_LAYOUT.A_FULLSCREEN.background]
+#      fill = "navy"        # uniform fill color
+#
+#   or
+#
+#     [A_LAYOUT.A_FULLSCREEN.background]
+#      rectangle = 1        # rectangle with frame/border
+#      fill = "navy"
+#      outline = "yellow"
+#      width = 3
+#
+#   or
+#
+#     [STATUS_LAYOUT.background]
+#      image = "images/mickey-sprite.png"   # assumed sized correctly
+#
+#
+#   As shown, the entry must be named "background".
+#
+# --------------------------------------------------------------------
+
 
 #
 # Default audio info screen

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -412,6 +412,7 @@ def fixup_layouts(nested_dict):
             newdict[key] = fixup_array(value)
         else:
             if ((key.startswith("color") or key == "lcolor" or
+                 key == "outline" or 
                  key == "fill" or key == "lfill") and
                     value.startswith("color_")):
                 # Lookup color

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -1260,8 +1260,33 @@ def text_fields(image, draw, layout, info, screen_mode=None, layout_name="", dyn
 # Second argument is a dictionary loaded from Kodi system status fields.
 # Third argument is dictionary holding JSON-RPC response from Kodi.
 #
+# Unlike audio_screen_static() and video_screen_static(), this
+# function is NOT expected to create a completely new image.  So, any
+# background fill is handled in a slightly different manner.
+#
 def status_screen(image, draw, kodi_status):
     layout = STATUS_LAYOUT
+
+    # Draw any user-specified rectangle or load background
+    # image for layout
+    if "background" in layout:
+        if ("rectangle" in layout["background"] and
+            layout["background"]["rectangle"]):
+            draw.rectangle(
+                [(0, 0), (_frame_size[0], _frame_size[1])],
+                fill    = layout["background"].get("fill","black"),
+                outline = layout["background"].get("outline","black"),
+                width   = layout["background"].get("width",1)
+            )
+        elif ("image" in layout["background"]):
+            pass
+        elif ("fill" in layout["background"]):
+            draw.rectangle(
+                [(0, 0), (_frame_size[0], _frame_size[1])],
+                fill    = layout["background"].get("fill","black"),
+                outline = "black",
+                width   = 1
+            )
 
     # Kodi logo, if desired
     if "thumb" in layout.keys():
@@ -1290,11 +1315,33 @@ def status_screen(image, draw, kodi_status):
 def audio_screen_static(layout, info):
     global _last_thumb, _last_image_path
 
-    # Create a new image
-    image = Image.new('RGB', (_frame_size), 'black')
+    # Create new Image and ImageDraw objects
+    if ("background" in layout and
+        "fill" in layout["background"] and
+        ("rectangle" not in layout["background"] or
+         not layout["background"]["rectangle"])):
+        image = Image.new('RGB', (_frame_size), layout["background"]["fill"])
+    else:
+        image = Image.new('RGB', (_frame_size), 'black')
+
     draw = ImageDraw.Draw(image)
 
-    # retrieve cover image from Kodi, if it exists and needs a refresh
+    # Draw any user-specified rectangle or load background
+    # image for layout
+    if "background" in layout:
+        if ("rectangle" in layout["background"] and
+            layout["background"]["rectangle"]):
+            draw.rectangle(
+                [(0, 0), (_frame_size[0], _frame_size[1])],
+                fill    = layout["background"].get("fill","black"),
+                outline = layout["background"].get("outline","black"),
+                width   = layout["background"].get("width",1)
+            )
+        elif ("image" in layout["background"]):
+            pass
+
+
+    # Retrieve cover image from Kodi, if it exists and needs a refresh
     if "thumb" in layout.keys():
         _last_thumb = get_artwork(info['MusicPlayer.Cover'], _last_thumb,
                                   layout["thumb"]["size"], layout["thumb"]["size"])
@@ -1448,9 +1495,31 @@ def audio_screens(image, draw, info, prog):
 def video_screen_static(layout, info):
     global _last_thumb, _last_image_path
 
-    # Create a new image
-    image = Image.new('RGB', (_frame_size), 'black')
+    # Create new Image and ImageDraw objects
+    if ("background" in layout and
+        "fill" in layout["background"] and
+        ("rectangle" not in layout["background"] or
+         not layout["background"]["rectangle"])):
+        image = Image.new('RGB', (_frame_size), layout["background"]["fill"])
+    else:
+        image = Image.new('RGB', (_frame_size), 'black')
+
     draw = ImageDraw.Draw(image)
+
+    # Draw any user-specified rectangle or load background
+    # image for layout
+    if "background" in layout:
+        if ("rectangle" in layout["background"] and
+            layout["background"]["rectangle"]):
+            draw.rectangle(
+                [(0, 0), (_frame_size[0], _frame_size[1])],
+                fill    = layout["background"].get("fill","black"),
+                outline = layout["background"].get("outline","black"),
+                width   = layout["background"].get("width",1)
+            )
+        elif ("image" in layout["background"]):
+            pass
+
 
     # Retrieve cover image from Kodi, if it exists and needs a refresh
     if "thumb" in layout.keys():

--- a/kodi_panel_display.py
+++ b/kodi_panel_display.py
@@ -1278,8 +1278,14 @@ def status_screen(image, draw, kodi_status):
                 outline = layout["background"].get("outline","black"),
                 width   = layout["background"].get("width",1)
             )
-        elif ("image" in layout["background"]):
-            pass
+
+        elif ("image" in layout["background"] and
+              os.path.isfile(layout["background"]["image"]) and
+              os.access(layout["background"]["image"], os.R_OK)):
+            # assume that image is properly sized for the display
+            bg_image = Image.open(layout["background"]["image"])
+            image.paste(bg_image, (0,0))
+
         elif ("fill" in layout["background"]):
             draw.rectangle(
                 [(0, 0), (_frame_size[0], _frame_size[1])],
@@ -1337,8 +1343,13 @@ def audio_screen_static(layout, info):
                 outline = layout["background"].get("outline","black"),
                 width   = layout["background"].get("width",1)
             )
-        elif ("image" in layout["background"]):
-            pass
+
+        elif ("image" in layout["background"] and
+              os.path.isfile(layout["background"]["image"]) and
+              os.access(layout["background"]["image"], os.R_OK)):
+            # assume that image is properly sized for the display
+            bg_image = Image.open(layout["background"]["image"])
+            image.paste(bg_image, (0,0))
 
 
     # Retrieve cover image from Kodi, if it exists and needs a refresh
@@ -1517,8 +1528,13 @@ def video_screen_static(layout, info):
                 outline = layout["background"].get("outline","black"),
                 width   = layout["background"].get("width",1)
             )
-        elif ("image" in layout["background"]):
-            pass
+
+        elif ("image" in layout["background"] and
+              os.path.isfile(layout["background"]["image"]) and
+              os.access(layout["background"]["image"], os.R_OK)):
+            # assume that image is properly sized for the display
+            bg_image = Image.open(layout["background"]["image"])
+            image.paste(bg_image, (0,0))
 
 
     # Retrieve cover image from Kodi, if it exists and needs a refresh


### PR DESCRIPTION
Permit all layouts to specify an optional `background` comprising one of the following:
- uniform fill color; or
- rectangle (with distinct fill color, outline color, and frame width); or
- image

